### PR TITLE
Add support for author meta tag

### DIFF
--- a/app/views/layouts/application.html.erb
+++ b/app/views/layouts/application.html.erb
@@ -4,6 +4,7 @@
   <title><%= html_title yield(:title) %></title>
   <%= csrf_meta_tag %>
   <%= stylesheet_link_tag 'application' %>
+  <meta name="author" content="<%= CONFIG['name'] %>">
   <link href="/posts.rss" rel="alternate" title="RSS" type="application/rss+xml" />
   <link href='http://fonts.googleapis.com/css?family=Lato:300,900' rel='stylesheet' type='text/css' />
 </head>


### PR DESCRIPTION
Hi Nate. Using the name value in the config.yml, you can add support for the author meta tag in the application.html.erb. Pretty simple commit but good to have nonetheless:

``` ruby
 `<meta name="author" content="<%= CONFIG['name'] %>">`
```
