### PR TITLE
don't load environment on precompile

### DIFF
--- a/config/application.rb
+++ b/config/application.rb
@@ -53,6 +53,9 @@ module Obtvse
     # Enable the asset pipeline
     config.assets.enabled = true
 
+    # Don't load the environment on precompile (fixes Heroku DB issue)
+    config.assets.initialize_on_precompile = false
+
     # Version of your assets, change this if you want to expire all your assets
     config.assets.version = '1.0'
   end


### PR DESCRIPTION
Heroku environment isn't loaded for precompiling assets, and connection to DB fails because ENV isn't available.
