### PR TITLE
Using application directory

### DIFF
--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -71,6 +71,7 @@ GEM
     net-ssh-gateway (1.1.0)
       net-ssh (>= 1.99.1)
     pg (0.12.2)
+    pg (0.12.2-x86-mingw32)
     polyglot (0.3.3)
     rack (1.4.1)
     rack-cache (1.2)
@@ -108,6 +109,7 @@ GEM
       rack (~> 1.0)
       tilt (~> 1.1, != 1.3.0)
     sqlite3 (1.3.5)
+    sqlite3 (1.3.5-x86-mingw32)
     thor (0.14.6)
     tilt (1.3.3)
     treetop (1.4.10)
@@ -120,6 +122,7 @@ GEM
 
 PLATFORMS
   ruby
+  x86-mingw32
 
 DEPENDENCIES
   capistrano

--- a/app/helpers/page_title_helper.rb
+++ b/app/helpers/page_title_helper.rb
@@ -9,7 +9,7 @@ module PageTitleHelper
 
   def page_title(content)
     @title = content || CONFIG['title']
-    render 'shared/title'
+    render partial: 'title'
   end
 
   def linked_title

--- a/app/helpers/page_title_helper.rb
+++ b/app/helpers/page_title_helper.rb
@@ -13,6 +13,6 @@ module PageTitleHelper
   end
 
   def linked_title
-    link_to CONFIG['title'], root_url
+    link_to CONFIG['title'], root_path
   end
 end

--- a/app/views/application/_title.html.erb
+++ b/app/views/application/_title.html.erb
@@ -1,0 +1,1 @@
+<h1><%= link_to @title, root_path %></h1>

--- a/app/views/shared/_title.html.erb
+++ b/app/views/shared/_title.html.erb
@@ -1,1 +1,0 @@
-<h1><a href="<%= root_url %>"><%= @title %></a></h1>


### PR DESCRIPTION
- Moving the `_title` partial to the `app/views/application` directory, where shared partials belong
- Dropping `shared/` from the render call in `page_title_helper.rb` since it's no longer needed
- Switching to using `*_path` instead of URL
- Using `link_to` instead of a regular `<a>` tag
