### PR TITLE
Changing .yml to support Heroku configs out of the box

### DIFF
--- a/app/controllers/posts_controller.rb
+++ b/app/controllers/posts_controller.rb
@@ -27,7 +27,7 @@ class PostsController < ApplicationController
 
 	def show
 		@show = true
-		@post = Post.find_by_slug_and_draft(params[:slug], false)
+		@post = Post.find_by_slug params[:slug]
 
 		respond_to do |format|
 			if @post.present?

--- a/config/config.yml
+++ b/config/config.yml
@@ -1,8 +1,8 @@
 ---
 title:               This is a blog.
 tagline:             This is not a clever tagline.
-login:               <%= ENV["blog_login"] %>
-password:            <%= ENV["blog_password"] %>
+login:               <%= ENV["blog_login"] ? ENV["blog_login"] : "user" %>
+password:            <%= ENV["blog_password"] ? ENV["blog_password"] : "password" %>
 name:                Matthew DuVall
 twitter:             maskact
 github:              maskact

--- a/config/config.yml
+++ b/config/config.yml
@@ -1,10 +1,10 @@
 ---
-title:               This is a blog.
-tagline:             This is not a clever tagline.
+title:               Title of your blog
+tagline:             Clever tagline.
 login:               <%= ENV["blog_login"] ? ENV["blog_login"] : "user" %>
 password:            <%= ENV["blog_password"] ? ENV["blog_password"] : "password" %>
-name:                Matthew DuVall
-twitter:             maskact
-github:              maskact
-email:               mduvall@berkeley.edu
+name:                Your name
+twitter:             your_twitter_handle
+github:              your_github_handle
+email:               address@example.com
 google_analytics_id: YOUR_GA_ID

--- a/config/config.yml
+++ b/config/config.yml
@@ -1,10 +1,10 @@
 ---
-title:               Title of Your Blog
-tagline:             Clever tagline.
-login:               CHANGE_ME
-password:            CHANGE_ME_123
-name:                Your Name
-twitter:             your_twitter_handle
-github:              your_github_handle
-email:               address@example.com
+title:               This is a blog.
+tagline:             This is not a clever tagline.
+login:               <%= ENV["blog_login"] %>
+password:            <%= ENV["blog_password"] %>
+name:                Matthew DuVall
+twitter:             maskact
+github:              maskact
+email:               mduvall@berkeley.edu
 google_analytics_id: YOUR_GA_ID


### PR DESCRIPTION
Since the aim seems to be to support an easier deployment via Heroku I added two lines that pull out two variables out of ENV for login and password. The user can set these via `heroku config:add blog_login=<BLOG_LOGIN> blog_password=<BLOG_PASSWORD>` and it will persist between deployments, then fall back to 'username' and 'password' locally or if it is not set.

Thoughts?
