### PR TITLE
Fixed a typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ For production, you will want to set your password in config.yml or with environ
 Or in your shell (~/.bashrc or ~/.zshrc for example)
 
     export obtvse_login=<LOGIN>
-    export obtvse_passowrd=<PASSWORD>
+    export obtvse_password=<PASSWORD>
 
 
 


### PR DESCRIPTION
The line in README.md containing examples of the config environment variables contained a typo. The "w" and "o" in "password" were transposed.
