### PR TITLE
Rake task to migrate from Wordpress

### DIFF
--- a/lib/tasks/migrate_wordpress.rake
+++ b/lib/tasks/migrate_wordpress.rake
@@ -1,0 +1,31 @@
+# -*- coding:utf-8 -*-
+# Usage rake wordpress:migrate_wordpress[:src, :dst]
+namespace :wordpress do
+    task :migrate_wordpress, [:src, :dst] => :environment do |cmd, args|
+      args.with_defaults(:src => "wordpress", :dst => "development")
+      config = Rails.configuration.database_configuration
+      src_db = config[args[:src]]
+      dst_db = config[args[:dst]]
+
+      conn = ActiveRecord::Base.establish_connection src_db
+      posts = conn.connection.execute 'SELECT * FROM wp_posts'
+
+      conn = ActiveRecord::Base.establish_connection dst_db
+      puts conn
+      posts.each do |post|
+          title = post[5].force_encoding 'utf-8'
+          content = post[4].force_encoding 'utf-8'
+          #TODO Test draft functionality
+          #TODO Date published
+          draft = post[7]  # Could be publish, draft or auto-draft
+
+          if draft.end_with? "draft"
+              draft = true
+          elsif draft.end_with? "publish"
+              draft = false
+          end
+
+          p = Post.create! :title => title, :content => content, :slug => Post.acts_as_url(:title, :url_attribute => :slug)
+      end
+    end
+end

--- a/lib/tasks/migrate_wordpress.rake
+++ b/lib/tasks/migrate_wordpress.rake
@@ -1,31 +1,34 @@
 # -*- coding:utf-8 -*-
 # Usage rake wordpress:migrate_wordpress[:src, :dst]
+# You will need gem "mysql" in your Gemfile
+
 namespace :wordpress do
     task :migrate_wordpress, [:src, :dst] => :environment do |cmd, args|
-      args.with_defaults(:src => "wordpress", :dst => "development")
-      config = Rails.configuration.database_configuration
-      src_db = config[args[:src]]
-      dst_db = config[args[:dst]]
+        args.with_defaults(:src => "wordpress", :dst => "development")
+        config = Rails.configuration.database_configuration
+        src_db = config[args[:src]]
+        dst_db = config[args[:dst]]
 
-      conn = ActiveRecord::Base.establish_connection src_db
-      posts = conn.connection.execute 'SELECT * FROM wp_posts'
+        conn = ActiveRecord::Base.establish_connection src_db
+        posts = conn.connection.execute "SELECT * FROM wp_posts where post_status='draft' or post_status='publish'"
 
-      conn = ActiveRecord::Base.establish_connection dst_db
-      puts conn
-      posts.each do |post|
-          title = post[5].force_encoding 'utf-8'
-          content = post[4].force_encoding 'utf-8'
-          #TODO Test draft functionality
-          #TODO Date published
-          draft = post[7]  # Could be publish, draft or auto-draft
+        conn = ActiveRecord::Base.establish_connection dst_db
 
-          if draft.end_with? "draft"
-              draft = true
-          elsif draft.end_with? "publish"
-              draft = false
-          end
+        posts.each do |post|
+            title = post[5].force_encoding 'utf-8'
+            content = post[4].force_encoding 'utf-8'
+            created_at = post[2]
+            updated_at = post[14]
+            draft = post[7]
 
-          p = Post.create! :title => title, :content => content, :slug => Post.acts_as_url(:title, :url_attribute => :slug)
-      end
+            if draft.end_with? "draft"
+                draft_flag = true
+            elsif draft.end_with? "publish"
+                draft_flag = false
+            end
+
+            p = Post.create! :title => title, :content => content, :slug => Post.acts_as_url(:title, :url_attribute => :slug),
+                             :created_at => created_at, :updated_at => updated_at, :draft => draft_flag
+        end
     end
 end


### PR DESCRIPTION
## Database migration from a Wordpress blog.
- In the Gemfile

``` ruby
gem "mysql"
```
- Add a database to the config/database.yml

``` ruby
wordpress:
  adapter: mysql
  encoding: utf8
  database: obtvse_example
  username: my_user
  password: my_pass
  host: localhost
```
- Finally it could be called from the command line…

``` ruby
rake wordpress:migrate_wordpress[source_db, destiny_db]
```

That's it :-)
