### PR TITLE
removed instruction to cp config/config.example.yml

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,7 +19,6 @@ If you are new to Rails development, check out guides for getting your developme
     cd obtvse
     bundle install
     rake db:migrate
-    cp config/config.example.yml config/config.yml
 
 Edit `config/config.yml` to set up your site information.  To set up your admin username and password you will need to set your environment variables.
 


### PR DESCRIPTION
This file no longer exists.
Removed the line in the README.md. The following line
correctly instructs the user to edit config/config.yml
