### PR TITLE
Add comma in posts.css.scss

### DIFF
--- a/app/assets/stylesheets/posts.css.scss
+++ b/app/assets/stylesheets/posts.css.scss
@@ -39,7 +39,7 @@ p {
 }
 
 a,
-a:visited
+a:visited,
 a:active {
   color: #000;
   text-decoration: none;

--- a/app/assets/stylesheets/posts.css.scss
+++ b/app/assets/stylesheets/posts.css.scss
@@ -38,9 +38,7 @@ p {
   color: #555;
 }
 
-a,
-a:visited,
-a:active {
+a {
   color: #000;
   text-decoration: none;
   border-bottom: 1px solid #ddd;


### PR DESCRIPTION
This is a minor issue, as Sass still properly compiles the
stylesheet. However, if the stylesheet is converted to less, then
the stylesheet doesn't quite compile correctly due to this missing
comma, and you end up with the browser's default link colors.
