### PR TITLE
Custom obtvse overrides for default Gist styling

### DIFF
--- a/app/assets/stylesheets/embed.css
+++ b/app/assets/stylesheets/embed.css
@@ -121,3 +121,14 @@
 .gist-syntax .vg { color: #008080 } /* Name.Variable.Global */
 .gist-syntax .vi { color: #008080 } /* Name.Variable.Instance */
 .gist-syntax .il { color: #009999 } /* Literal.Number.Integer.Long */
+
+
+/* Custom obtvse overrides for Gist styling  */
+.gist td.line_numbers { display:none; }
+.gist td.line_data pre { line-height: 1.2em; }
+.gist .gist-file .gist-data pre {font-size: smaller; padding: .1em .1em .1em 0.6em !important; }
+.gist .highlight { border-left: 22px solid #eee; position: relative; }
+.gist .highlight  { counter-reset: linenumbers; }
+.gist .highlight pre div:before {  color: #3aa1c9; content: counter(linenumbers); 
+   counter-increment: linenumbers; left: -11px; position: absolute; text-align: right; width: 10px; }
+/* End of custom Gist styling  */


### PR DESCRIPTION
## Custom obtvse overrides for Gist styling
### The issue
- Default embedded gist line numbers do not support word wrapping and hence break when wrapping is enforced in pages/divs with limited width: they no longer match the lines and generally are crudely styled
- Embedded gists inherit some **obtvse** styling better suited for posts/content rather then code
### The solution

This commit adds a few css rules to achieve the following:
- hide the default gist line numbers and implement css-counter
    based line numbering, accommodating word wraps and perfect fit between
    numbers and lines
- line-height and font-size modified for better presentation of code;
    previously they inherited obtvse styling for post text and presentation
### A picture is worth a thousand words
#### Picture Before

![before](https://f.cloud.github.com/assets/285772/94020/f3e39574-663d-11e2-8055-6718cf1e2a07.png)
#### Picture After

![after](https://f.cloud.github.com/assets/285772/94021/fa4e62ae-663d-11e2-9957-52479cdc622c.png)
